### PR TITLE
リポジトリ名変更に伴う、README の Circle CI Badge のリンク修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LTVOD
 
-[![CircleCI](https://circleci.com/gh/0918nobita/LTVOD/tree/master.svg?style=svg&circle-token=c8b93630f04d2834afbcd86f5043345e4cfb6d90)](https://circleci.com/gh/0918nobita/LTVOD/tree/master) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2F0918nobita%2FLTVOD.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2F0918nobita%2FLTVOD?ref=badge_shield)
+[![CircleCI](https://circleci.com/gh/0918nobita/RCC_TV.svg?style=svg)](https://circleci.com/gh/0918nobita/RCC_TV) [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2F0918nobita%2FLTVOD.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2F0918nobita%2FLTVOD?ref=badge_shield)
 
 ## 開発環境構築
 


### PR DESCRIPTION
概要
---

リポジトリ名を「LTVOD」から「RCC_TV」に変更したことに伴って、Circle CI のバッジの正規のリンク先が変更されていたので修正した。

スクリーンショット 
---

### before

<img width="289" alt="スクリーンショット 2019-04-21 20 30 00" src="https://user-images.githubusercontent.com/8453302/56469449-f1f72280-6474-11e9-9346-7f90a6224d91.png">

### after

<img width="302" alt="スクリーンショット 2019-04-21 20 29 47" src="https://user-images.githubusercontent.com/8453302/56469453-f6bbd680-6474-11e9-9341-d99e1f05de62.png">
