### PR TITLE
query関数のParams型の追加

### DIFF
--- a/workspaces/backend/src/utils/sql.ts
+++ b/workspaces/backend/src/utils/sql.ts
@@ -1,5 +1,16 @@
 import MySQL from 'mysql';
 
+export type Params<T> =
+  | number
+  | boolean
+  | Date
+  | Buffer
+  | string
+  | { [K in keyof T]: T[keyof T] }
+  | { toSqlString(): string; [key: string]: any }
+  | undefined
+  | null;
+
 export const connect = (connection: MySQL.Connection) =>
   new Promise<void>((resolve: () => void, reject) => {
     connection.connect(err => {
@@ -14,7 +25,7 @@ export const connect = (connection: MySQL.Connection) =>
 export function query<T>(
   connection: MySQL.Connection,
   queryString: string,
-  params: (string | string[])[] = []
+  params: (Params<T> | Params<T>[])[] = []
 ) {
   return new Promise((resolve: (rows: T[]) => void, reject) => {
     connection.query(queryString, params, (err, rows) => {

--- a/workspaces/backend/src/video/router.ts
+++ b/workspaces/backend/src/video/router.ts
@@ -10,6 +10,35 @@ export const router = Router();
 
 // endpoint prefix: /video
 
+router.get('/latest', async (req: Request, res: Response) => {
+  const records: string = req.query.records;
+
+  const connection = MySQL.createConnection(dbConfig);
+
+  try {
+    await connect(connection);
+    const videos = await query<VideosRecord>(
+      connection,
+      'SELECT * FROM videos ORDER BY modified DESC LIMIT ?',
+      [Number.parseInt(records)]
+    );
+    res.json(
+      videos.map(video =>
+        Object.assign(video, {
+          created: moment(video.created).format('YYYY年M月D日 H:m'),
+          modified: moment(video.modified).format('YYYY年M月D日 H:m'),
+        })
+      )
+    );
+  } catch (e) {
+    console.log(e);
+    res.writeHead(500);
+    res.end();
+  } finally {
+    connection.end();
+  }
+});
+
 router.get('/:videoId', async (req: Request, res: Response) => {
   const videoId: string = req.params.videoId;
 


### PR DESCRIPTION
概要
---

 sparkles 更新日順に指定件数動画メタデータを取得するAPIの実装
`sql.ts` の `query` 関数でエスケープされるパラメータの型を `MySQL.query` のパラメータの型にしました。

変更項目
---

- query関数のParams型を追加
- 更新日順に指定件数動画メタデータを取得するAPIの実装

関連リンク
---

https://github.com/mysqljs/mysql#escaping-query-values
