### PR TITLE
MySQLのquery関数のParams型を追加

### DIFF
--- a/workspaces/backend/src/utils/sql.ts
+++ b/workspaces/backend/src/utils/sql.ts
@@ -1,5 +1,16 @@
 import MySQL from 'mysql';
 
+export type Params<T> =
+  | number
+  | boolean
+  | Date
+  | Buffer
+  | string
+  | { [K in keyof T]: T[keyof T] }
+  | { toSqlString(): string; [key: string]: any }
+  | undefined
+  | null;
+
 export const connect = (connection: MySQL.Connection) =>
   new Promise<void>((resolve: () => void, reject) => {
     connection.connect(err => {

--- a/workspaces/backend/src/utils/sql.ts
+++ b/workspaces/backend/src/utils/sql.ts
@@ -25,7 +25,7 @@ export const connect = (connection: MySQL.Connection) =>
 export function query<T>(
   connection: MySQL.Connection,
   queryString: string,
-  params: (string | string[])[] = []
+  params: (Params<T> | Params<T>[])[] = []
 ) {
   return new Promise((resolve: (rows: T[]) => void, reject) => {
     connection.query(queryString, params, (err, rows) => {


### PR DESCRIPTION
概要
---

`MySQL.query` 関数の引数に合わせたParams型を追加しました。

変更項目
---

- Params型の追加
- 関数の引数paramsの型を変更

参考リンク
---

https://github.com/mysqljs/mysql#escaping-query-values